### PR TITLE
Fix body close and allow GAE to geocode

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,3 +68,19 @@ Then:
     }
   }
 ```
+
+If using Google App Engine, you'll need to set the geocode request's HTTPClient:
+
+```
+	import (
+		"appengine"
+		"appengine/urlfetch"
+	)
+
+	c := appengine.NewContext(req)
+
+	geoReq := &geocode.Request{
+		HTTPClient: urlfetch.Client(c),
+		// ...
+	}
+```


### PR DESCRIPTION
The response body should be closed after checking if the err is non
nil.

Adds a property to the Request type to allow the caller to specify
their own HTTPClient. Note: this overrides any transport specified
by the caller.
