### PR TITLE
Required updates for GOOGLE and OSM usage (key + new JSON reply). Also: nice example of leveraging both for batch queries.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ geocode
 
 Go package for interacting with:
 - Google's Geocoding API
-- OSM's Nomatin API
+- OSM's Nomatin API (To be more precise: MapQuestApi's Geocoding API)
 - YOUR's routing API
 
 For Google's GEOCODING:
@@ -12,33 +12,73 @@ For Google's GEOCODING:
 	req := &geocode.Request{
 		Region:   "us",
 		Provider: geocode.GOOGLE,
-		Location: &geocode.Point{34.64973, -98.41503}
+		Key: "YOUR_GOOGLE_MAPS_API_KEY",
+		Location: &geocode.Point{34.64973, -98.41503},
   }
 ```
 
-For OSM GEOCODING:
+For OSM/MAPQUEST GEOCODING:
 ```
 	req := &geocode.Request{
 		Provider: geocode.OSM,
 		Limit:    1,
-		Location: &geocode.Point{34.64973, -98.41503}
+		Region: "ar",
+		Key: "YOUR_MAPQUEST_API_KEY",
+		Location: &geocode.Point{34.64973, -98.41503},
 	}
 ```
 
-Then:
+Let's say you need to reverse geocode locations, and want to rely on all providers. First we hit OSM/MAPQUEST, then fall back to GOOGLE:
+
 ```
-  resp, err := req.Lookup(nil)
-  if err != nil {
-		//fmt.Printf("Lookup error: %v\n", err)
-		continue
-  } else {
-    if s := resp.Status; s != "OK" {
-			continue
-			//fmt.Printf(`%s: sStatus == %q\n`, req.Location, s)
-    } else {
-			fmt.Printf("---> result[%d]: %s\n", resp.Count, resp.Found)
-    }
-  }
+	req := &geocode.Request{
+		Limit:  1,
+		Type:   geocode.GEOCODE,
+		Region: "ar",
+		Location: &geocode.Point{-34.649966, -58.421769},
+	}
+
+	sucessfulLookup := false
+
+	req.Provider = geocode.OSM
+	req.Key = "YOUR_MAPQUEST_API_KEY"
+
+	resp, err := req.Lookup(nil)
+	if err != nil {
+		// fmt.Printf("Lookup error: %v - %v \n", resp, err)
+	} else {
+		// fmt.Printf("----> OSM query string is: %s \n", resp.QueryString)
+		if s := resp.Status; s != "OK" {
+			fmt.Printf(`%s: sStatus == %q \n`, req.Location, s)
+		} else {
+			if resp.Count > 0 {
+				sucessfulLookup = true
+			}
+		}
+	}
+
+	if !sucessfulLookup {
+		req.Provider = geocode.GOOGLE
+		req.Key = "YOUR_GOOGLE_MAPS_API_KEY"
+
+		resp, err = req.Lookup(nil)
+		if err != nil {
+			// fmt.Printf("Lookup error: %v\n", err)
+		} else {
+			// fmt.Printf("----> Google query string is: %s \n", resp.QueryString)
+			if s := resp.Status; s != "OK" {
+				fmt.Printf(`%s: sStatus == %q \n`, req.Location, s)
+			} else {
+				sucessfulLookup = true
+			}
+		}
+
+	}
+
+	if sucessfulLookup {
+		fmt.Printf("%s \n", resp.Found)
+		time.Sleep(time.Duration(rand.Intn(200-1)+1) * time.Millisecond)
+	}
 ```
 
 Additionally, you could do routing. 


### PR DESCRIPTION
Both providers now require an API key to geocode. Added this to Google and MapQuest requests.

Both utilize "results" in their JSON reply - which would incorrectly decode to the wrong pointer. Depending on provider, we forcefully decode to a different struct which fixes this.

OSM/MapQuest has a new URL, as well as JSON reply. Updated the expected JSON for decoding

Added a really nice example of leveraging both OSM/MapQuest as well as GOOGLE for batch queries
